### PR TITLE
Cleanup markdown

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -136,4 +136,5 @@ If you want to contribute to this list (please do), send me a pull request or co
 
 <a name="xml" />
 #### XML
+
 * [XML Indent](http://xmlindent.sourceforge.net/) - XML stream reformatter written in ANSI C.

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ If you want to contribute to this list (please do), send me a pull request or co
 <!-- MarkdownTOC depth=4 -->
 - [General Purpose](#general-purpose)
 - [Language Specific](#language-specific)
-  - [C/C++](#c-cpp)
+  - [C/C++](#cc)
   - [Cobol](#cobol)
   - [CSS](#css)
   - [Fortran](#fortran)
@@ -21,17 +21,15 @@ If you want to contribute to this list (please do), send me a pull request or co
   - [.NET](#net)
   - [Perl](#perl)
   - [PHP](#php)
-  - [PL/SQL](#pl-sql)
+  - [PL/SQL](#plsql)
   - [Python](#python)
   - [Ruby](#ruby)
   - [Shell](#shell)
   - [VBS](#vbs)
   - [XML](#xml)
 
-
 <!-- /MarkdownTOC -->
 
-<a name="general-purpose" />
 ## General Purpose
 
 * [Artistic Styler](http://astyle.sourceforge.net/) - Source code indenter, formatter, and beautifier for the C, C++, C# and Java programming languages.
@@ -40,101 +38,83 @@ If you want to contribute to this list (please do), send me a pull request or co
 
 <a name="language-specific" />
 
-<a name="c-cpp" />
 #### C/C++
 
 * [BCPP](http://invisible-island.net/bcpp/) - indents C/C++ source programs, replacing tabs with spaces or the reverse.
 * [GNU Indent](http://www.gnu.org/software/indent/) -  Unix utility that reformats C and C++ code in a user-defined indent style and coding style. GNU style is used by default.
 * [GreatCode](http://sourceforge.net/projects/gcgreatcode/) - C/C++ source code beautifier that is now fully open source.
 
-<a name="cobol" />
 #### Cobol
 
 * [Cobol Beautifier](http://www.siber.com/sct/tools/cbl-beau.html) - Parses your program just like a real Cobol compiler and then it generates Cobol code from the resulting Cobol Program Tree.
 
-<a name="css" />
 #### CSS
 
 * [CSSTidy](http://csstidy.sourceforge.net/) - Opensource CSS parser and optimiser available as executeable file which can be controlled by command line and as PHP script.
 
-<a name="fortran" />
 #### Fortran
 
 * [Fortran 90 PPR](ftp://ftp.ifremer.fr/ifremer/fortran90/) - Fortran 90 preprocessor and formatter written in Fortran 90.
 
-<a name="haskell" />
 #### Haskell
 
 * [hindent](https://github.com/chrisdone/hindent) - Extensible Haskell pretty printer available both as a library and an executable.
 
-<a name="html" />
 #### HTML
 
 * [HTB](http://www.digital-mines.com/htb/) - Command-line utility to reformat HTML/XML/XSLT source code with an array of user specified options.
 * [Tidy](http://tidy.sourceforge.net/) - Free-standing C library
 
-<a name="java" />
 #### Java
 
 * [Google Java Format](https://github.com/google/google-java-format) - google-java-format is a program that reformats Java source code to comply with Google Java Style.
 * [JALOPY](http://notzippy.github.io/JALOPY2-MAIN/) - Source code formatting tool for the Sun Java Programming Language.
 * [Jindent](http://www.jindent.com/) - Commercial source code formatter for the programming languages Java, C and C++
 
-<a name="javascript" />
 #### JavaScript
 
 * [JsDecoder](http://bdgn.net/JsDecoder.html) -  Deobfuscator for JavaScript
 
-<a name="jsp" />
 #### JSP
 
 * [JSPPP](http://jsppp.sourceforge.net/) - Indentor for JSP files in various styles.
 
-<a name="net" />
 #### .NET
 
 * [NArrange](http://www.narrange.net/) - Code beautifier that automatically organizes code members and elements within .NET classes.
 
-<a name="perl" />
 #### Perl
 
 * [PerlTidy](http://perltidy.sourceforge.net/) -  Perl script which indents and reformats Perl scripts.
 
-<a name="php" />
 #### PHP
 
 * [PHP_Beautifier](http://pear.php.net/package/PHP_Beautifier) - Beautifier for PHP
 * [phpCB](http://www.waterproof.fr/products/phpCodeBeautifier/) - Tool available as a GUI, command line and an integrated tool of PHPEdit.
 * [phpStylist](http://sourceforge.net/projects/phpstylist/) - Formatter with customizable options.
 
-<a name="pl-sql" />
 #### PL/SQL
 
 * [Pl/Sql tidy](http://psti.equinoxbase.com/) - Program to tidy, beautify or format Pl/Sql code in a batch file or Dos prompt.
 * [Poor Man's T-SQL Formatter](http://architectshack.com/PoorMansTSqlFormatter.ashx) - .Net 2.0 library with demo UI, command-line bulk formatter, SSMS/Visual Studio add-in, notepad++ plugin, winmerge plugin, and web service for reformatting and coloring T-SQL code to the user's preferences.
 
-<a name="python" />
 #### Python
 
 * [pindent](http://svn.python.org/projects/python/trunk/Tools/scripts/pindent.py) - Adds comments when blocks are closed, or can properly indent code if comments are put in.
 * [yapf](https://github.com/google/yapf) - A formatter for Python files.
 
-<a name="ruby" />
 #### Ruby
 
 * [Ruby Script Beautifier](http://www.arachnoid.com/ruby/rubyBeautifier.html) - Beautifier written in Ruby.
 
-<a name="shell" />
 #### Shell
 
 * [ShellIndent](http://www.bolthole.com/AWK.html) - Indent formatting program for .sh scripts.
 
-<a name="vbs" />
 #### VBS
 
 * [VBSBeautifier](http://www.daansystems.com/vbsbeaut/) - Beautifier for ASP and clientside VBScript files.
 
-<a name="xml" />
 #### XML
 
 * [XML Indent](http://xmlindent.sourceforge.net/) - XML stream reformatter written in ANSI C.

--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ If you want to contribute to this list (please do), send me a pull request or co
 * [Uncrustify](http://uncrustify.sourceforge.net/) - Beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and VALA.
 * [clang-format](http://clang.llvm.org/docs/ClangFormat.html) - Automatic formatting for C, C++, Java, JavaScript, ObjectiveC and Protobuf.
 
-<a name="language-specific" />
+## Language Specific
 
 #### C/C++
 


### PR DESCRIPTION
Nice project! These commits remove the `a` tags, which break Github's markdown formatter, replacing them with the links Github creates for markdown headers. I'm assuming Github is your primary method of displaying this information?

Thanks!